### PR TITLE
Display target ciphertext when starting brute force script

### DIFF
--- a/deterministic_bruteforce.py
+++ b/deterministic_bruteforce.py
@@ -254,6 +254,8 @@ def main():
     modulus_len = len(target)
     pubkey_path = write_temp_key()
     padding_modes = ("none", "pkcs1", "default")
+    print("Target ciphertext (hex):")
+    print(TARGET_CIPHER_HEX)
     log_path = os.path.join(os.getcwd(), "bruteforce_attempts_log.csv")
     example_attempts_to_print = 5
     printed_examples = 0


### PR DESCRIPTION
## Summary
- print the hardcoded target ciphertext before running the brute force search so it is visible immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d0b70ec883249c029d5850f36e88