### PR TITLE
Add lead generation agent menu configuration

### DIFF
--- a/config/lead_generation_agent_menu.json
+++ b/config/lead_generation_agent_menu.json
@@ -1,0 +1,46 @@
+{
+  "menus": [
+    {"id": "home", "label": "Home", "level": "L0"},
+    {"id": "reports", "label": "Reports", "level": "L0"},
+    {"id": "settings", "label": "Settings", "level": "L0"},
+    {
+      "id": "ai-lead-agent",
+      "label": "AI Lead Agent (Lead Generation Agent)",
+      "level": "L0",
+      "position": "end",
+      "children": [
+        {"id": "overview", "label": "Overview", "level": "L1"},
+        {"id": "playbooks", "label": "Playbooks", "level": "L1"},
+        {"id": "scenarios", "label": "Scenarios", "level": "L1"}
+      ]
+    }
+  ],
+  "agents": {
+    "leadGeneration": {
+      "name": "AI Lead Agent (Lead Generation Agent)",
+      "sections": [
+        {
+          "id": "overview",
+          "title": "Overview",
+          "content": "Summarizes the AI-driven workflow for qualifying inbound leads."
+        },
+        {
+          "id": "playbooks",
+          "title": "Playbooks",
+          "content": "Contains reusable outreach strategies and cadences."
+        },
+        {
+          "id": "scenarios",
+          "title": "Scenarios",
+          "content": "Shows curated example interactions for the agent."
+        }
+      ],
+      "display": {
+        "scenarioReferences": [
+          {"id": "scenario-1", "title": "Scenario 1: First-touch outreach"},
+          {"id": "scenario-2", "title": "Scenario 2: Re-engagement follow-up"}
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a lead generation agent configuration file
- set the AI Lead Agent menu entry to an L0 item placed at the end of the menu
- remove the API reference scenarios section and Scenario 3 display reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3983ed89483248c8b3731e9721af2